### PR TITLE
Add debug-gui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,13 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+debug-gui = ["eframe","egui", "egui_file"]
+
 [dependencies]
 clap = { version = "4.5.9", features = ["derive"] }
 unicode-segmentation = "1.11.0"
+
+eframe = { version = "0.27.2", optional = true }
+egui = { version = "0.27.2", optional = true }
+egui_file = { version = "0.17.0", optional = true }

--- a/src/bin/debug_gui/mod.rs
+++ b/src/bin/debug_gui/mod.rs
@@ -1,0 +1,156 @@
+use crate::HashMap;
+
+use eframe::egui;
+
+use egui_file::FileDialog;
+use std::{
+  ffi::OsStr,
+  path::{Path, PathBuf},
+};
+
+use crate::compile;
+use crate::Program;
+use sid::ExeState;
+use sid::ProgramValue;
+use sid::interpret_one;
+use sid::get_built_in_functions;
+use sid::ToSyntax;
+
+pub struct SidDebuggerApp {
+    exe_state: Option<ExeState>,
+
+    opened_file: Option<PathBuf>,
+    open_file_dialog: Option<FileDialog>,
+}
+
+impl SidDebuggerApp {
+    pub fn new() -> Self {
+        Self {
+            exe_state: None,
+            opened_file: None,
+            open_file_dialog: None,
+        }
+    }
+}
+
+impl eframe::App for SidDebuggerApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::TopBottomPanel::top("top_panel").show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                ui.style_mut().spacing.interact_size.y *= 1.4;
+                ui.style_mut()
+                    .text_styles
+                    .get_mut(&egui::TextStyle::Button)
+                    .unwrap()
+                    .size *= 1.4;
+
+                if (ui.button("Open")).clicked() {
+                    // Show only files with the extension "sid".
+                    let filter = Box::new({
+                        let ext = Some(OsStr::new("sid"));
+                        move |path: &Path| -> bool { path.extension() == ext }
+                    });
+                    let mut dialog = FileDialog::open_file(self.opened_file.clone()).show_files_filter(filter);
+                    dialog.open();
+                    self.open_file_dialog = Some(dialog);
+                }
+
+                if ui.button("Reset").clicked() {
+                    *self = Self::new();
+                }
+                if ui.button("Step").clicked() || ui.input(|i| i.key_pressed(egui::Key::F10)) {
+                    if let Some(exe_state) = &mut self.exe_state {
+                        interpret_one(
+                            exe_state,
+                            &get_built_in_functions()
+                        );
+                    }
+                }
+            });
+
+            if let Some(dialog) = &mut self.open_file_dialog {
+                if dialog.show(ctx).selected() {
+                    if let Some(file) = dialog.path() {
+                        self.opened_file = Some(file.to_path_buf());
+                        let file_content = std::fs::read_to_string(self.opened_file.as_ref().unwrap())
+                            .expect("Failed to read file");
+
+                        let program = compile(&file_content);
+                        let exe_state = ExeState {
+                            program_stack: vec![ProgramValue::Invoke],
+                            data_stack: program.instructions,
+                            local_scope: HashMap::new(),
+                            global_scope: program.global_scope,
+                        };
+                        self.exe_state = Some(exe_state);
+                    }
+                }
+            }
+        });
+
+        egui::CentralPanel::default().show(ctx, |ui| {
+            let mut painter_size = ui.available_size_before_wrap();
+            if !painter_size.is_finite() {
+                painter_size = egui::vec2(500.0, 500.0);
+            }
+
+            if self.exe_state.is_none() {
+                return;
+            }
+
+            // Display stuff 
+            ui.label(format!("File: {:?}", self.opened_file.as_ref().unwrap()));
+            ui.horizontal(|ui| {
+                
+                ui.vertical(|ui| {
+                    ui.label("program stack");
+                    ui.label("-------------");
+                    let exe_state = self.exe_state.as_ref().unwrap();
+                    for (i, program_value) in exe_state.program_stack.iter().enumerate() {
+                        ui.label(format!("{}: {}", i, program_value.to_syntax()));
+                    }
+                });
+                ui.vertical(|ui| {
+                    for data in 0..10 {
+                        ui.label("|");
+                    }
+                });
+                ui.vertical(|ui| {
+                    ui.label("data stack");
+                    ui.label("-------------");
+                    let exe_state = self.exe_state.as_ref().unwrap();
+                    for (i, data) in exe_state.data_stack.iter().enumerate() {
+                        ui.label(format!("{}: {}", i, data.to_syntax()));
+                    }
+                });
+                ui.vertical(|ui| {
+                    for data in 0..10 {
+                        ui.label("|");
+                    }
+                });
+                ui.vertical(|ui| {
+                    ui.label("local scope");
+                    ui.label("-------------");
+                    let exe_state = self.exe_state.as_ref().unwrap();
+                    for (key, _data) in exe_state.local_scope.iter() {
+                        ui.label(format!("{:?}", key));
+                    }
+                });
+                ui.vertical(|ui| {
+                    for data in 0..10 {
+                        ui.label("|");
+                    }
+                });
+                ui.vertical(|ui| {
+                    ui.label("global scope");
+                    ui.label("-------------");
+                    let exe_state = self.exe_state.as_ref().unwrap();
+                    for (key, _data) in exe_state.global_scope.iter() {
+                        ui.label(format!("{:?}", key));
+                    }
+                });
+            });
+        });
+    }
+}
+

--- a/src/bin/sid.rs
+++ b/src/bin/sid.rs
@@ -4,24 +4,80 @@ use sid::*;
 
 use clap::Parser;
 
+#[cfg(feature= "debug-gui")]
+mod debug_gui;
+
 #[derive(Parser)]
 #[command(version)]
 struct CliArgs {
   /// Path to file to execute code from or `-` for stdin
   file: String,
 }
+
+#[cfg(not(feature = "debug-gui"))]
 fn main() {
   let cli = CliArgs::parse();
-  // Create a String from the file
-  let file_content = std::fs::read_to_string(cli.file.clone())
-    .expect("Failed to read file");
+  run_file(&cli.file.clone());
+}
 
+
+#[cfg(feature = "debug-gui")]
+#[cfg(target_arch = "wasm32")]
+fn main() {
+    // Make sure panics are logged using `console.error`.
+    console_error_panic_hook::set_once();
+
+    // Redirect tracing to console.log and friends:
+    tracing_wasm::set_as_global_default();
+
+    let web_options = eframe::WebOptions::default();
+
+    wasm_bindgen_futures::spawn_local(async {
+        eframe::start_web(
+            "canvas",
+            web_options,
+            Box::new(|_cc| Box::new(debug_gui::SidDebuggerApp::new())),
+        )
+        .await
+        .expect("failed to start eframe");
+    });
+}
+
+#[cfg(feature = "debug-gui")]
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {
+    let options = eframe::NativeOptions {
+        ..Default::default()
+    };
+    let res = eframe::run_native(
+        "Sid - Debugger",
+        options,
+        Box::new(|_cc| Box::new(debug_gui::SidDebuggerApp::new())),
+    );
+
+    if res.is_err() {
+        println!("Error: {:?}", res);
+    }
+}
+
+fn run_file(path: &str) {
+  // Create a String from the file
+  let file_content = std::fs::read_to_string(path)
+    .expect("Failed to read file");
+  run(&file_content);
+}
+
+struct Program {
+  instructions: Vec<DataValue>,
+  global_scope: HashMap<String, RealValue>,
+}
+
+fn compile(source: & str) -> Program {
   // Parse that String into Vec<TemplateValue>
-  let parsed = parse_str(&file_content);
+  let parsed = parse_str(source);
   // Create the global scope, with built-in functions and constants
   // (Implementations of this don't yet exist)
-  let mut global_scope = HashMap::new();
-  let built_in_functions = HashMap::new();
+  let global_scope = HashMap::new();
   // Render that Vec<TemplateValue> as a Substack
   let rendered = render_template(
     Template::substack(parsed),
@@ -29,15 +85,23 @@ fn main() {
     &mut HashMap::new(), // Current local scope, not applicable
     &global_scope,
   );
+  return Program{
+    instructions: rendered,
+    global_scope,
+  };
+}
+
+fn run(source: &str) {
+  let program = compile(source);
   // The rendering output is the whole data stack initially
   // And an invoke the whole program
   let program_stack = vec![ProgramValue::Invoke];
-  let mut data_stack = rendered;
+  let data_stack = program.instructions;
+  let built_in_functions = get_built_in_functions();
   interpret(
     program_stack,
-    &mut data_stack,
-    global_scope,
+    data_stack,
+    program.global_scope,
     &built_in_functions,
   );
-  println!("{:?}", data_stack);
 }

--- a/src/bin/sid.rs
+++ b/src/bin/sid.rs
@@ -7,6 +7,11 @@ use clap::Parser;
 #[cfg(feature= "debug-gui")]
 mod debug_gui;
 
+struct Program {
+  instructions: Vec<DataValue>,
+  global_scope: HashMap<String, RealValue>,
+}
+
 #[derive(Parser)]
 #[command(version)]
 struct CliArgs {
@@ -65,11 +70,6 @@ fn run_file(path: &str) {
   let file_content = std::fs::read_to_string(path)
     .expect("Failed to read file");
   run(&file_content);
-}
-
-struct Program {
-  instructions: Vec<DataValue>,
-  global_scope: HashMap<String, RealValue>,
 }
 
 fn compile(source: & str) -> Program {

--- a/src/built_in/mod.rs
+++ b/src/built_in/mod.rs
@@ -1,8 +1,15 @@
 use std::collections::HashMap;
 
-use crate::{
-  RealValue,
-  ProgramValue,
-  DataValue,
-};
+use crate::BuiltInFunction;
 
+// use crate::{
+//   RealValue,
+//   ProgramValue,
+//   DataValue,
+// };
+
+
+// Well this is obviously shit, but until later
+pub fn get_built_in_functions() -> HashMap<&'static str, &'static dyn BuiltInFunction> {
+  HashMap::new()
+}

--- a/src/invoke/mod.rs
+++ b/src/invoke/mod.rs
@@ -8,6 +8,12 @@ use super::{
   render_template,
 };
 
+pub struct ExeState {
+  pub program_stack: Vec<ProgramValue>,
+  pub data_stack: Vec<DataValue>,
+  pub local_scope: HashMap<String, RealValue>,
+  pub global_scope: HashMap<String, RealValue>,
+}
 
 // Invoking behaves very differently depending on what is invoked
 pub fn invoke<'a>(
@@ -75,12 +81,6 @@ pub fn interpret<'a>(
 }
 
 
-pub struct ExeState {
-  pub program_stack: Vec<ProgramValue>,
-  pub data_stack: Vec<DataValue>,
-  pub local_scope: HashMap<String, RealValue>,
-  pub global_scope: HashMap<String, RealValue>,
-}
 
 pub fn interpret_one<'a>(
   exe_state: &mut ExeState,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,16 @@
 // (This allows mocking all side effects in one for testing)
 mod types;
 pub use types::*;
+mod to_syntax;
+pub use to_syntax::*;
 mod parse;
 pub use parse::*;
 mod render;
 pub use render::*;
 mod invoke;
 pub use invoke::*;
+mod built_in;
+pub use built_in::*;
 //
 //
 //pub fn interpret_str(

--- a/src/to_syntax.rs
+++ b/src/to_syntax.rs
@@ -69,8 +69,8 @@ impl ToSyntax for TemplateData {
 impl ToSyntax for TemplateValue {
   fn to_syntax(&self) -> String {
       match self {
-        TemplateValue::ParentLabel(v) => format!("{} #Parent Label", v),
-        TemplateValue::ParentStackMove(v) => format!("sm {}", v), // Not super sure what this is
+        TemplateValue::ParentLabel(v) => format!("${}", v),
+        TemplateValue::ParentStackMove(v) => format!("${}", v),
         TemplateValue::Literal(v) => v.to_syntax(),
       }
   }

--- a/src/to_syntax.rs
+++ b/src/to_syntax.rs
@@ -1,0 +1,77 @@
+
+use crate::types::*;
+
+pub trait ToSyntax
+where 
+  Self: Sized {
+    fn to_syntax(&self) -> String;
+}
+
+fn list_to_syntax<T: ToSyntax>(list: &[T], left_bracket: &str, right_bracket: &str) -> String {
+  let mut s = left_bracket.to_owned();
+  for item in list.iter() {
+    s = format!("{}\n {} ", s, &item.to_syntax());
+  }
+  format!("{}\n{} ", s, right_bracket)
+}
+
+impl ToSyntax for DataValue {
+  fn to_syntax(&self) -> String {
+    match self {
+      DataValue::Real(v) => v.to_syntax(),
+      DataValue::Label(v) => v.clone(),
+    }
+  }
+}
+impl ToSyntax for RealValue {
+  fn to_syntax(&self) -> String {
+    match self {
+      RealValue::Bool(v) => v.to_string(),
+      RealValue::Str(v) => format!("\"{}\"", v.clone()),
+      RealValue::Char(v) => format!("\'{}\'", v.clone()),
+      RealValue::Int(v) => v.to_string(),
+      RealValue::Float(v) => v.to_string(),
+      RealValue::Substack(v) => {
+        list_to_syntax(v, "{", "}")
+      },
+      RealValue::List(v) => {
+        list_to_syntax(v, "[", "]")
+      },
+      RealValue::BuiltInFunction(v) => v.clone(),
+    }
+  }
+}
+
+impl ToSyntax for ProgramValue {
+  fn to_syntax(&self) -> String {
+    match self {
+      ProgramValue::Real(v) => v.to_syntax(),
+      ProgramValue::Label(v) => v.clone(),
+      ProgramValue::Invoke => "!".to_owned(),
+      ProgramValue::Template(v) => v.data.to_syntax(),
+    }
+  }
+}
+
+impl ToSyntax for TemplateData {
+  fn to_syntax(&self) -> String {
+    match self {
+      TemplateData::SubstackTemplate(v) => {
+        list_to_syntax(v, "{ #Template", "}")
+      },
+      TemplateData::ListTemplate(v) => {
+        list_to_syntax(v, "[ #Template", "]")
+      },
+    }
+  }
+}
+
+impl ToSyntax for TemplateValue {
+  fn to_syntax(&self) -> String {
+      match self {
+        TemplateValue::ParentLabel(v) => format!("{} #Parent Label", v),
+        TemplateValue::ParentStackMove(v) => format!("sm {}", v), // Not super sure what this is
+        TemplateValue::Literal(v) => v.to_syntax(),
+      }
+  }
+}


### PR DESCRIPTION
Since a gui has a lot of dependencies, it was added as an optional feature it is quite shitty, but that's the first step.
Currently displays the program + data stack, and the local + global scope Added some to_syntax methods to make it easier to look at

The GUI allows one to step through the execution and see the state as it evolves. Kinda assumed I would be able to do this with a regular debugger but mine was non-cooprative. And this lays some groundwork for later regardless.